### PR TITLE
Use case-insensitive comparison for token type

### DIFF
--- a/authentication/token.go
+++ b/authentication/token.go
@@ -86,7 +86,7 @@ func checkTokenFormat(token string) (string, error) {
 	}
 
 	tokenType, userToken := tokenParts[0], tokenParts[1]
-	if tokenType != "bearer" {
+	if !strings.EqualFold(tokenType, "bearer") {
 		return "", errors.New("Invalid token type: " + tokenType)
 	}
 

--- a/authentication/token_test.go
+++ b/authentication/token_test.go
@@ -52,12 +52,20 @@ var _ = Describe("Token", func() {
 
 				signedKey, err = token.SignedString([]byte(UserPrivateKey))
 				Expect(err).NotTo(HaveOccurred())
-
-				signedKey = "bearer " + signedKey
 			})
 
 			It("does not return an error", func() {
-				err := accessToken.DecodeToken(signedKey, "route.advertise")
+				err := accessToken.DecodeToken("bearer "+signedKey, "route.advertise")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("does not return an error if the token type string is capitalized", func() {
+				err := accessToken.DecodeToken("Bearer "+signedKey, "route.advertise")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("does not return an error if the token type string is uppercase", func() {
+				err := accessToken.DecodeToken("BEARER "+signedKey, "route.advertise")
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
The current routing-api behavior is currently not accepting a valid (as per https://tools.ietf.org/html/rfc6750#section-2.1) authorization header starting with "Bearer ".

This PR modifies the token_type validation behavior as the Cloud Controller is currently doing ( ref:
https://github.com/cloudfoundry/cloud_controller_ng/blob/965dbc4bdf65df89f382329aef39f86a916b3f05/lib/vcap/uaa_token_decoder.rb#L42 )

This is a nice article describing how token_type is defined in the specs: http://sgeb.io/articles/fix-go-oauth2-case-sensitive-bearer-auth-headers/