### PR TITLE
New /routing/v1/health endpoint for service health monitoring

### DIFF
--- a/cmd/routing-api/main.go
+++ b/cmd/routing-api/main.go
@@ -323,6 +323,7 @@ func apiHandler(cfg config.Config, uaaClient uaaclient.TokenValidator, database 
 	tcpMappingsHandler := handlers.NewTcpRouteMappingsHandler(uaaClient, validator, database, int(cfg.MaxTTL.Seconds()), logger)
 
 	actions := rata.Handlers{
+		routing_api.CheckHealth:           route(routesHandler.Health),
 		routing_api.UpsertRoute:           route(routesHandler.Upsert),
 		routing_api.DeleteRoute:           route(routesHandler.Delete),
 		routing_api.ListRoute:             route(routesHandler.List),

--- a/db/db_sql.go
+++ b/db/db_sql.go
@@ -23,6 +23,7 @@ import (
 
 //go:generate counterfeiter -o fakes/fake_db.go . DB
 type DB interface {
+	CheckHealth() error
 	ReadRoutes() ([]models.Route, error)
 	SaveRoute(route models.Route) error
 	DeleteRoute(route models.Route) error
@@ -359,6 +360,15 @@ func notImplementedError() error {
 	pc, _, _, _ := runtime.Caller(1)
 	fnName := runtime.FuncForPC(pc).Name()
 	return fmt.Errorf("function not implemented: %s", fnName)
+}
+
+func (s *SqlDB) CheckHealth() error {
+	var routes []models.Route
+	err := s.Client.First(&routes)
+	if err != nil {
+		return fmt.Errorf("checking health error: %v", err)
+	}
+	return nil
 }
 
 func (s *SqlDB) ReadRoutes() ([]models.Route, error) {

--- a/handlers/middleware.go
+++ b/handlers/middleware.go
@@ -12,8 +12,9 @@ func LogWrap(handler http.Handler, logger lager.Logger) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		requestLog := logger.Session("request", lager.Data{
-			"method":  r.Method,
-			"request": r.URL.String(),
+			"remoteAddr": r.RemoteAddr,
+			"method":     r.Method,
+			"request":    r.URL.String(),
 		})
 
 		requestLog.Info("serving", lager.Data{"request-headers": filter(r.Header)})

--- a/routes.go
+++ b/routes.go
@@ -3,6 +3,7 @@ package routing_api
 import "github.com/tedsuo/rata"
 
 const (
+	CheckHealth           = "Health"
 	UpsertRoute           = "UpsertRoute"
 	DeleteRoute           = "Delete"
 	ListRoute             = "List"
@@ -17,7 +18,9 @@ const (
 	EventStreamTcpRoute   = "TcpRouteEventStream"
 )
 
-var RoutesMap = map[string]rata.Route{UpsertRoute: {Path: "/routing/v1/routes", Method: "POST", Name: UpsertRoute},
+var RoutesMap = map[string]rata.Route{
+	CheckHealth:           {Path: "/routing/v1/health", Method: "GET", Name: CheckHealth},
+	UpsertRoute:           {Path: "/routing/v1/routes", Method: "POST", Name: UpsertRoute},
 	DeleteRoute:           {Path: "/routing/v1/routes", Method: "DELETE", Name: DeleteRoute},
 	ListRoute:             {Path: "/routing/v1/routes", Method: "GET", Name: ListRoute},
 	EventStreamRoute:      {Path: "/routing/v1/events", Method: "GET", Name: EventStreamRoute},


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Implemented the new `/routing/v1/health` endpoint for service health monitoring.
This endpoint is used by the `routing_api_health_check.sh` script in the `routing-release`.

Backward Compatibility
---------------
Breaking Change? **No**
