### PR TITLE
fix: Resolve MySQL error 1170 in AutoMigrate migrations

### DIFF
--- a/migration/V10_sni_rewrite_hostname.go
+++ b/migration/V10_sni_rewrite_hostname.go
@@ -18,5 +18,26 @@ func (v *V10SniRewriteHostname) Version() int {
 }
 
 func (v *V10SniRewriteHostname) Run(sqlDB *db.SqlDB) error {
-	return sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+	// CRITICAL FIX: Drop index BEFORE AutoMigrate to avoid MySQL error 1170
+	// when Gorm v2 tries to change VARCHAR columns to LONGTEXT
+	dropIndex(sqlDB, "idx_tcp_route", "tcp_routes")
+
+	// Run AutoMigrate to add the SniRewriteHostname column
+	err := sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+	if err != nil {
+		return err
+	}
+
+	// Recreate unique index with proper MySQL prefix lengths for LONGTEXT columns
+	// Note: SniRewriteHostname is NOT part of the unique index (no unique_index tag in model)
+	var indexSQL string
+	if sqlDB.Client.Dialect().Name() == "mysql" {
+		// MySQL requires prefix lengths for TEXT/LONGTEXT columns in indexes
+		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid(191), host_port, host_ip(191), external_port, sni_hostname(191), host_tls_port, terminate_frontend_tls)"
+	} else {
+		// PostgreSQL doesn't require prefix lengths
+		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid, host_port, host_ip, external_port, sni_hostname, host_tls_port, terminate_frontend_tls)"
+	}
+
+	return sqlDB.Client.ExecWithError(indexSQL)
 }

--- a/migration/V5_sni_hostname_migration.go
+++ b/migration/V5_sni_hostname_migration.go
@@ -18,19 +18,23 @@ func (v *V5SniHostnameMigration) Version() int {
 }
 
 func (v *V5SniHostnameMigration) Run(sqlDB *db.SqlDB) error {
+	// FIXED: Drop index BEFORE AutoMigrate to avoid MySQL error 1170
+	// when Gorm v2 tries to change VARCHAR columns to LONGTEXT
+	dropIndex(sqlDB, "idx_tcp_route", "tcp_routes")
+
+	// Run AutoMigrate to add the SniHostname column
 	err := sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
 	if err != nil {
 		return err
 	}
 
-	// Drop old index if it exists (ignore errors since it might not exist)
-	dropIndex(sqlDB, "idx_tcp_route", "tcp_routes")
-
-	// Create unique index - MySQL requires length prefixes for text columns
+	// Recreate unique index with proper MySQL prefix lengths for LONGTEXT columns
 	var indexSQL string
 	if sqlDB.Client.Dialect().Name() == "mysql" {
+		// MySQL requires prefix lengths for TEXT/LONGTEXT columns in indexes
 		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid(191), host_port, host_ip(191), external_port, sni_hostname(191))"
 	} else {
+		// PostgreSQL doesn't require prefix lengths
 		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid, host_port, host_ip, external_port, sni_hostname)"
 	}
 	return sqlDB.Client.ExecWithError(indexSQL)

--- a/migration/V6_tls_tcp_route.go
+++ b/migration/V6_tls_tcp_route.go
@@ -18,18 +18,23 @@ func (v *V6TCPTLSRoutes) Version() int {
 }
 
 func (v *V6TCPTLSRoutes) Run(sqlDB *db.SqlDB) error {
+	// FIXED: Drop index BEFORE AutoMigrate to avoid MySQL error 1170
+	// when Gorm v2 tries to change VARCHAR columns to LONGTEXT
+	dropIndex(sqlDB, "idx_tcp_route", "tcp_routes")
+
+	// Run AutoMigrate to add the HostTLSPort column
 	err := sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
 	if err != nil {
 		return err
 	}
 
-	dropIndex(sqlDB, "idx_tcp_route", "tcp_routes")
-
-	// Create unique index - MySQL requires length prefixes for text columns
+	// Recreate unique index with proper MySQL prefix lengths for LONGTEXT columns
 	var indexSQL string
 	if sqlDB.Client.Dialect().Name() == "mysql" {
+		// MySQL requires prefix lengths for TEXT/LONGTEXT columns in indexes
 		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid(191), host_port, host_ip(191), external_port, sni_hostname(191), host_tls_port)"
 	} else {
+		// PostgreSQL doesn't require prefix lengths
 		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid, host_port, host_ip, external_port, sni_hostname, host_tls_port)"
 	}
 	return sqlDB.Client.ExecWithError(indexSQL)

--- a/migration/V9_terminate_frontend_tls.go
+++ b/migration/V9_terminate_frontend_tls.go
@@ -18,5 +18,24 @@ func (v *V9TerminateFrontendTLS) Version() int {
 }
 
 func (v *V9TerminateFrontendTLS) Run(sqlDB *db.SqlDB) error {
-	return sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+	// FIXED: Drop index BEFORE AutoMigrate to avoid MySQL error 1170
+	// when Gorm v2 tries to change VARCHAR columns to LONGTEXT
+	dropIndex(sqlDB, "idx_tcp_route", "tcp_routes")
+
+	// Run AutoMigrate to add the TerminateFrontendTLS column
+	err := sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+	if err != nil {
+		return err
+	}
+
+	// Recreate unique index with proper MySQL prefix lengths for LONGTEXT columns
+	var indexSQL string
+	if sqlDB.Client.Dialect().Name() == "mysql" {
+		// MySQL requires prefix lengths for TEXT/LONGTEXT columns in indexes
+		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid(191), host_port, host_ip(191), external_port, sni_hostname(191), host_tls_port, terminate_frontend_tls)"
+	} else {
+		// PostgreSQL doesn't require prefix lengths
+		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid, host_port, host_ip, external_port, sni_hostname, host_tls_port, terminate_frontend_tls)"
+	}
+	return sqlDB.Client.ExecWithError(indexSQL)
 }


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This commit fixes MySQL error 1170 ("BLOB/TEXT column used in key specification without a key length") that occurs during routing-release upgrades when Gorm v2 attempts to change VARCHAR columns to LONGTEXT while indexes exist.

Changes:
- V5: Move dropIndex before AutoMigrate to prevent index conflicts
- V6: Move dropIndex before AutoMigrate to prevent index conflicts
- V9: Add complete dropIndex→AutoMigrate→recreateIndex pattern
- V10: Add complete dropIndex→AutoMigrate→recreateIndex pattern

Root Cause:
- Gorm v1→v2 changed default string mapping from VARCHAR to LONGTEXT
- MySQL requires prefix lengths for LONGTEXT columns in indexes
- AutoMigrate calls were attempting column changes with existing indexes

Impact:
- Enables 0.346.0→0.380.0 routing-release upgrades
- Prevents MySQL migration failures in V5,V6,V9,V10 migrations
- Maintains PostgreSQL compatibility (no prefix lengths required)

Fixes: routing-release upgrade path to 0.380.0+ from versions where V5, V6, V9, or V10 migrations were not yet run. 


Backward Compatibility
---------------
Breaking Change? no