### PR TITLE
Add EnableBackendMTLS to the route

### DIFF
--- a/db/db_sql.go
+++ b/db/db_sql.go
@@ -494,11 +494,11 @@ func (s *SqlDB) FindExistingTcpRouteMapping(tcpMapping models.TcpRouteMapping) (
 	// this where clause should represent all fields marked with the unique index on the TcpRouteMapping model,
 	// to ensure it returns the correct record from the database
 	if tcpMapping.SniHostname == nil {
-		err = s.Client.Where("router_group_guid = ? and host_ip = ? and host_port = ? and external_port = ? and host_tls_port = ? and sni_hostname IS NULL",
-			tcpMapping.RouterGroupGuid, tcpMapping.HostIP, tcpMapping.HostPort, tcpMapping.ExternalPort, tcpMapping.HostTLSPort).Find(&routes)
+		err = s.Client.Where("router_group_guid = ? and host_ip = ? and host_port = ? and external_port = ? and host_tls_port = ? and sni_hostname IS NULL and enable_backend_m_tls = ?",
+			tcpMapping.RouterGroupGuid, tcpMapping.HostIP, tcpMapping.HostPort, tcpMapping.ExternalPort, tcpMapping.HostTLSPort, tcpMapping.EnableBackendMTLS).Find(&routes)
 	} else {
-		err = s.Client.Where("router_group_guid = ? and host_ip = ? and host_port = ? and external_port = ? and host_tls_port = ? and sni_hostname = ?",
-			tcpMapping.RouterGroupGuid, tcpMapping.HostIP, tcpMapping.HostPort, tcpMapping.ExternalPort, tcpMapping.HostTLSPort, tcpMapping.SniHostname).Find(&routes)
+		err = s.Client.Where("router_group_guid = ? and host_ip = ? and host_port = ? and external_port = ? and host_tls_port = ? and sni_hostname = ? and enable_backend_m_tls = ?",
+			tcpMapping.RouterGroupGuid, tcpMapping.HostIP, tcpMapping.HostPort, tcpMapping.ExternalPort, tcpMapping.HostTLSPort, tcpMapping.SniHostname, tcpMapping.EnableBackendMTLS).Find(&routes)
 	}
 
 	if err != nil {

--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -957,7 +957,7 @@ var _ = Describe("SqlDB", func() {
 					It("returns an empty routemapping", func() {
 						By("Finding all the unique fields in a struct")
 						uniqueFields := parseAllUniqueFieldsFromTcpMapping(tcpRoute)
-						Expect(len(uniqueFields)).To(Equal(6))
+						Expect(len(uniqueFields)).To(Equal(7))
 
 						for _, field := range uniqueFields {
 							By(fmt.Sprintf("testing when the %s field is different", field))
@@ -979,6 +979,8 @@ var _ = Describe("SqlDB", func() {
 							case "SniHostname":
 								sniHostname := "new-sni-hostname"
 								routeToTest.SniHostname = &sniHostname
+							case "EnableBackendMTLS":
+								routeToTest.EnableBackendMTLS = true
 							default:
 								Fail("unexpected unique field found on models.TcpRouteMapping. Please update this test to account for it")
 							}

--- a/migration/V11_enable_backend_mtls.go
+++ b/migration/V11_enable_backend_mtls.go
@@ -1,0 +1,41 @@
+package migration
+
+import (
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/models"
+)
+
+type V11EnableBackendMTLS struct{}
+
+var _ Migration = new(V11EnableBackendMTLS)
+
+func NewV11EnableBackendMTLS() *V11EnableBackendMTLS {
+	return &V11EnableBackendMTLS{}
+}
+
+func (v *V11EnableBackendMTLS) Version() int {
+	return 11
+}
+
+func (v *V11EnableBackendMTLS) Run(sqlDB *db.SqlDB) error {
+	// Drop index BEFORE AutoMigrate to avoid MySQL error 1170
+	// when Gorm v2 tries to change VARCHAR columns to LONGTEXT
+	dropIndex(sqlDB, "idx_tcp_route", "tcp_routes")
+
+	// Run AutoMigrate to add the EnableBackendMTLS column
+	err := sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+	if err != nil {
+		return err
+	}
+
+	// Recreate unique index with proper MySQL prefix lengths for LONGTEXT columns
+	var indexSQL string
+	if sqlDB.Client.Dialect().Name() == "mysql" {
+		// MySQL requires prefix lengths for TEXT/LONGTEXT columns in indexes
+		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid(191), host_port, host_ip(191), external_port, sni_hostname(191), host_tls_port, terminate_frontend_tls, enable_backend_m_tls)"
+	} else {
+		// PostgreSQL doesn't require prefix lengths
+		indexSQL = "CREATE UNIQUE INDEX idx_tcp_route ON tcp_routes (router_group_guid, host_port, host_ip, external_port, sni_hostname, host_tls_port, terminate_frontend_tls, enable_backend_m_tls)"
+	}
+	return sqlDB.Client.ExecWithError(indexSQL)
+}

--- a/migration/V11_enable_backend_mtls_test.go
+++ b/migration/V11_enable_backend_mtls_test.go
@@ -1,0 +1,193 @@
+package migration_test
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/migration"
+	v7 "code.cloudfoundry.org/routing-api/migration/v7"
+	"code.cloudfoundry.org/routing-api/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("V11EnableBackendMTLS", func() {
+	var (
+		sqlDB       *db.SqlDB
+		dbAllocator testrunner.DbAllocator
+	)
+
+	BeforeEach(func() {
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
+		Expect(err).NotTo(HaveOccurred())
+
+		sqlDB, err = db.NewSqlDB(sqlCfg)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := dbAllocator.Delete()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	runTests := func() {
+		Context("during migration", func() {
+			It("allows the migration to occur", func() {
+				v11Migration := migration.NewV11EnableBackendMTLS()
+				err := v11Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(1))
+				// The existing route should default to EnableBackendMTLS=false after migration
+				Expect(routes[0].EnableBackendMTLS).To(Equal(false))
+			})
+		})
+		Context("After migration", func() {
+			var tcpRoute1 models.TcpRouteMapping
+
+			BeforeEach(func() {
+				v11Migration := migration.NewV11EnableBackendMTLS()
+				err := v11Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 = models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-1"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     443,
+						HostIP:          "1.2.3.4",
+						InstanceId:      "instanceId1",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+
+						ModificationTag:      models.ModificationTag{},
+						TTL:                  nil,
+						IsolationSegment:     "",
+						TerminateFrontendTLS: false,
+						ALPNs:                "",
+						EnableBackendMTLS:    true,
+					},
+				}
+			})
+
+			It("expect no error to occur when creating a route with enable_backend_mtls", func() {
+				_, err := sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+
+				var createdRoute models.TcpRouteMapping
+				err = sqlDB.Client.Where("guid = ?", "guid-1").First(&createdRoute)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(createdRoute.EnableBackendMTLS).To(Equal(true))
+			})
+
+			It("allows creating a route without enable_backend_mtls (false)", func() {
+				tcpRoute1.EnableBackendMTLS = false
+				_, err := sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+
+				var createdRoute models.TcpRouteMapping
+				err = sqlDB.Client.Where("guid = ?", "guid-1").First(&createdRoute)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(createdRoute.EnableBackendMTLS).To(Equal(false))
+			})
+
+			It("allows two otherwise-identical routes that differ only by enable_backend_mtls", func() {
+				_, err := sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+
+				sibling := tcpRoute1
+				sibling.Model = models.Model{Guid: "guid-2"}
+				sibling.EnableBackendMTLS = false
+
+				_, err = sqlDB.Client.Create(&sibling)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	}
+
+	Describe("Version", func() {
+		It("returns 11 for the version", func() {
+			v11Migration := migration.NewV11EnableBackendMTLS()
+			Expect(v11Migration.Version()).To(Equal(11))
+		})
+	})
+
+	Describe("Run", func() {
+		Context("when there are existing tables with the old tcp_route model", func() {
+			BeforeEach(func() {
+				err := sqlDB.Client.AutoMigrate(&v7.RouterGroupDB{}, &v7.TcpRouteMapping{}, &v7.Route{})
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 := v7.TcpRouteMapping{
+					Model:     v7.Model{Guid: "guid-0"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: v7.TcpMappingEntity{
+						RouterGroupGuid: "test0",
+						HostPort:        80,
+						HostIP:          "1.2.3.4",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+
+				_, err = sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+
+				v11Migration := migration.NewV11EnableBackendMTLS()
+				err = v11Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			runTests()
+		})
+
+		Context("when the tables are newly created (by V0 init migration)", func() {
+			BeforeEach(func() {
+				v0Migration := migration.NewV0InitMigration()
+				err := v0Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Run all migrations up to V10
+				v9Migration := migration.NewV9TerminateFrontendTLS()
+				err = v9Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				v10Migration := migration.NewV10SniRewriteHostname()
+				err = v10Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-0"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid:      "test0",
+						HostPort:             80,
+						HostTLSPort:          100,
+						HostIP:               "1.2.3.4",
+						SniHostname:          &sniHostname1,
+						InstanceId:           "",
+						ExternalPort:         80,
+						ModificationTag:      models.ModificationTag{},
+						TTL:                  nil,
+						IsolationSegment:     "",
+						TerminateFrontendTLS: false,
+						ALPNs:                "",
+					},
+				}
+
+				_, err = sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			runTests()
+		})
+	})
+})

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -108,6 +108,9 @@ func InitializeMigrations() []Migration {
 	migration = NewV10SniRewriteHostname()
 	migrations = append(migrations, migration)
 
+	migration = NewV11EnableBackendMTLS()
+	migrations = append(migrations, migration)
+
 	return migrations
 }
 

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Migration", func() {
 				done := make(chan struct{})
 				defer close(done)
 				migrations := migration.InitializeMigrations()
-				Expect(migrations).To(HaveLen(10))
+				Expect(migrations).To(HaveLen(11))
 
 				Expect(migrations[0]).To(BeAssignableToTypeOf(new(migration.V0InitMigration)))
 				Expect(migrations[1]).To(BeAssignableToTypeOf(new(migration.V2UpdateRgMigration)))
@@ -55,6 +55,7 @@ var _ = Describe("Migration", func() {
 				Expect(migrations[7]).To(BeAssignableToTypeOf(new(migration.V8HostTLSPortTCPDefaultZero)))
 				Expect(migrations[8]).To(BeAssignableToTypeOf(new(migration.V9TerminateFrontendTLS)))
 				Expect(migrations[9]).To(BeAssignableToTypeOf(new(migration.V10SniRewriteHostname)))
+				Expect(migrations[10]).To(BeAssignableToTypeOf(new(migration.V11EnableBackendMTLS)))
 			})
 		})
 

--- a/models/tcp_route.go
+++ b/models/tcp_route.go
@@ -35,7 +35,8 @@ type TcpMappingEntity struct {
 	IsolationSegment     string `json:"isolation_segment"`
 	TerminateFrontendTLS bool   `gorm:"default:false" json:"terminate_frontend_tls,omitempty"`
 	// alpns is a csv value
-	ALPNs string `json:"alpns,omitempty"`
+	ALPNs             string `json:"alpns,omitempty"`
+	EnableBackendMTLS bool   `gorm:"default:false; unique_index:idx_tcp_route" json:"enable_backend_mtls,omitempty"`
 }
 
 func (TcpRouteMapping) TableName() string {

--- a/models/tcp_route_test.go
+++ b/models/tcp_route_test.go
@@ -175,6 +175,20 @@ var _ = Describe("TCP Route", func() {
 					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
 				})
 			})
+
+			Context("when two routes are equal and EnableBackendMTLS are different", func() {
+				JustBeforeEach(func() {
+					tcpRouteMapping2.SniHostname = tcpRouteMapping.SniHostname
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
+
+					tcpRouteMapping.EnableBackendMTLS = false
+					tcpRouteMapping2.EnableBackendMTLS = true
+				})
+
+				It("matches()", func() {
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
+				})
+			})
 		})
 	})
 })


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Explicitly opt in MTLS between TCP router and backend for backwards compatibility


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
