### PR TITLE
Use the configured (5s) locket retry interval over aggressive 1s

### DIFF
--- a/cmd/routing-api/main.go
+++ b/cmd/routing-api/main.go
@@ -135,7 +135,7 @@ func main() {
 		lockIdentifier,
 		locket.DefaultSessionTTLInSeconds,
 		clock,
-		locket.SQLRetryInterval,
+		cfg.RetryInterval,
 	)})
 
 	if len(locks) == 0 {


### PR DESCRIPTION
Very fast retries can cause a DoS in locket as existing requests pile up and must be processed 1-at-a-time before new requests are executed (due to SELECT FOR UPDATE holding the row lock)

Summary
=====
My environment is slow enough where I occasionally see a locket request take longer than 1s. Components with a 1s retry will give up on the request because it take to long and then immediately make another request for ~15 retries. None of them succeed because they pile up on each other at the locket server.

